### PR TITLE
Add a missing protocol conformance to ClientTransport

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -52,7 +52,7 @@ import Foundation
 /// The ``URLSessionTransport/Configuration-swift.struct`` type allows you to
 /// provide a custom URLSession and tweak behaviors such as the default
 /// timeouts, authentication challenges, and more.
-public struct URLSessionTransport {
+public struct URLSessionTransport: ClientTransport {
 
     /// A set of configuration values for the URLSession transport.
     public struct Configuration: Sendable {

--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -59,7 +59,7 @@ class URLSessionTransportTests: XCTestCase {
                 body: Data("👋".utf8)
             )
         )
-        let transport = URLSessionTransport(
+        let transport: ClientTransport = URLSessionTransport(
             configuration: .init(session: MockURLProtocol.mockURLSession)
         )
         let request = OpenAPIRuntime.Request(


### PR DESCRIPTION
### Motivation

We lost URLSessionTransport's conformance to ClientTransport along the way somewhere. But that's kind of its main job :)

### Modifications

Re-add the conformance.

### Result

Now the transport can be used as a ClientTransport again.

### Test Plan

Explicitly cast the test transport to be a ClientTransport, rather than using the concrete type.
