### PR TITLE
Add .github/release.yml to automate drafting release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none
+        - "*"


### PR DESCRIPTION
### Motivation

We want to provide consistent and comprehensive release notes when making
a release. Github supports generating draft release notes based on labels
attached to PRs to make this simpler.

### Modifications

- Add .github/release.yml with SemVer based release notes sections.

### Result

When creating a release, Github should populate the release notes based on the
PRs that have been merged since the last release and group them based on their
labels.

### Test Plan

None.

### Reference

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
