### PR TITLE
Fix double encoding of path parameters

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -160,7 +160,7 @@ extension URLRequest {
         guard var baseUrlComponents = URLComponents(string: baseURL.absoluteString) else {
             throw URLSessionTransportError.invalidRequestURL(request: request, baseURL: baseURL)
         }
-        baseUrlComponents.path += request.path
+        baseUrlComponents.percentEncodedPath += request.path
         baseUrlComponents.percentEncodedQuery = request.query
         guard let url = baseUrlComponents.url else {
             throw URLSessionTransportError.invalidRequestURL(request: request, baseURL: baseURL)

--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -32,7 +32,7 @@ class URLSessionTransportTests: XCTestCase {
 
     func testRequestConversion() throws {
         let request = OpenAPIRuntime.Request(
-            path: "/hello/Maria",
+            path: "/hello%20world/Maria",
             query: "greeting=Howdy",
             method: .post,
             headerFields: [
@@ -41,7 +41,7 @@ class URLSessionTransportTests: XCTestCase {
             body: Data("👋".utf8)
         )
         let urlRequest = try URLRequest(request, baseURL: URL(string: "http://example.com/api")!)
-        XCTAssertEqual(urlRequest.url, URL(string: "http://example.com/api/hello/Maria?greeting=Howdy"))
+        XCTAssertEqual(urlRequest.url, URL(string: "http://example.com/api/hello%20world/Maria?greeting=Howdy"))
         XCTAssertEqual(urlRequest.httpMethod, "POST")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields, ["X-Mumble": "mumble"])
         XCTAssertEqual(urlRequest.httpBody, Data("👋".utf8))


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/251.

### Modifications

Use the already escaped path setter on `URLComponents` to avoid the second encoding pass.

### Result

Path parameters that needed escaping are only escaped once, not twice.

### Test Plan

Adapted the existing unit test to cover a path item that needs escaping.
