### PR TITLE
Add docker-compose file for 5.10 CI

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -2,11 +2,10 @@ version: "3"
 
 services:
   runtime-setup:
-    image: &image swift-openapi-urlsession:22.04-5.9
+    image: &image swift-openapi-urlsession:22.04-5.10
     build:
       args:
-        ubuntu_version: "jammy"
-        swift_version: "5.9"
+        base_image: "swiftlang/swift:nightly-5.10-jammy"
 
   test:
     image: *image


### PR DESCRIPTION
### Motivation

Now Swift 5.9 is released and 5.10 nightly images are available, we should update our CI to use the official release for 5.10 and setup a new CI for 5.10.
 
### Modifications

- Update 5.9 CI to use `swift:5.9-jammy`
- Add new CI for `swiftlang/swift:nightly-5.10-jammy`

### Result

- 5.9 CI is using official released image.
- 5.10 CI can be brought online.

### Test Plan

Running both of these commands locally succeed:

```console
% docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.59.yaml run test
```
```console
% docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.510.yaml run test
```
