### PR TITLE
Bump swift-format to 5.9

### DIFF
--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -115,12 +115,16 @@ class MockURLProtocol: URLProtocol {
 
     static let recordedHTTPRequests = LockedValueBox<[URLRequest]>([])
 
+    /// Determines whether this protocol can handle the given request.
     override class func canInit(with request: URLRequest) -> Bool { true }
 
+    /// Returns a canonical version of the given request.
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
+    /// Stops protocol-specific loading of a request.
     override func stopLoading() {}
 
+    /// Starts protocol-specific loading of a request.
     override func startLoading() {
         Self.recordedHTTPRequests.withValue { $0.append(self.request) }
         guard let url = self.request.url else { return }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swift-format
-ARG swiftformat_version=508.0.0
+ARG swiftformat_version=509.0.0
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/apple/swift-format $HOME/.tools/swift-format-source
 RUN cd $HOME/.tools/swift-format-source && swift build -c release
 RUN ln -s $HOME/.tools/swift-format-source/.build/release/swift-format $HOME/.tools/swift-format


### PR DESCRIPTION
### Motivation

As per https://github.com/apple/swift-openapi-generator/issues/175.

### Modifications

Bumped swift-format for CI, no other changes needed.

### Result

Using swift-format 5.9.

### Test Plan

Soundness passed.
