### PR TITLE
Enable documentation comment validation in swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -16,7 +16,7 @@
   "prioritizeKeepingFunctionOutputTogether" : false,
   "respectsExistingLineBreaks" : true,
   "rules" : {
-    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AllPublicDeclarationsHaveDocumentation" : true,
     "AlwaysUseLowerCamelCase" : false,
     "AmbiguousTrailingClosureOverload" : true,
     "BeginDocumentationCommentWithOneLineSummary" : false,
@@ -50,7 +50,7 @@
     "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,
     "UseWhereClausesInForLoops" : false,
-    "ValidateDocumentationComments" : false
+    "ValidateDocumentationComments" : true
   },
   "spacesAroundRangeFormationOperators" : false,
   "tabWidth" : 8,

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -72,8 +72,7 @@ public struct URLSessionTransport: ClientTransport {
         public var session: URLSession
 
         /// Creates a new configuration with the provided session.
-        /// - Parameters:
-        ///     - session: The URLSession used for performing HTTP operations.
+        /// - Parameter session: The URLSession used for performing HTTP operations.
         ///     If none is provided, the system uses the shared URLSession.
         public init(session: URLSession = .shared) {
             self.session = session
@@ -84,12 +83,20 @@ public struct URLSessionTransport: ClientTransport {
     public var configuration: Configuration
 
     /// Creates a new URLSession-based transport.
-    /// - Parameters:
-    ///   - configuration: A set of configuration values used by the transport.
+    /// - Parameter configuration: A set of configuration values used by the transport.
     public init(configuration: Configuration = .init()) {
         self.configuration = configuration
     }
 
+    /// Asynchronously sends an HTTP request and returns the response and body.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request to be sent.
+    ///   - body: The HTTP body to include in the request (optional).
+    ///   - baseURL: The base URL for the request.
+    ///   - operationID: An optional identifier for the operation or request.
+    /// - Returns: A tuple containing the HTTP response and an optional HTTP response body.
+    /// - Throws: An error if there is a problem sending the request or processing the response.
     public func send(
         _ request: HTTPRequest,
         body: HTTPBody?,
@@ -218,10 +225,12 @@ extension URLRequest {
 }
 
 extension URLSessionTransportError: LocalizedError {
+    /// A custom error description for `URLSessionTransportError`.
     public var errorDescription: String? { description }
 }
 
 extension URLSessionTransportError: CustomStringConvertible {
+    /// A custom textual representation for `URLSessionTransportError`.
     public var description: String {
         switch self {
         case let .invalidRequestURL(path: path, method: method, baseURL: baseURL):

--- a/Tests/OpenAPIURLSessionTests/Locking.swift
+++ b/Tests/OpenAPIURLSessionTests/Locking.swift
@@ -28,9 +28,18 @@ public final class LockedValueBox<Value: Sendable>: @unchecked Sendable {
         return lock
     }()
     private var value: Value
+    /// Initializes a new `LockedValueBox` instance with the provided initial value.
+    ///
+    /// - Parameter value: The initial value to store in the `LockedValueBox`.
     public init(_ value: Value) {
         self.value = value
     }
+    /// Perform an operation on the value in a synchronized manner.
+    ///
+    /// - Parameter work: A closure that takes an inout reference to the wrapped value and returns a result.
+    ///
+    /// - Returns: The result of the provided closure.
+    /// - Returns: The result of the closure passed to `work`.
     public func withValue<R>(_ work: (inout Value) throws -> R) rethrows -> R {
         lock.lock()
         defer {


### PR DESCRIPTION
### Motivation

- Relates to https://github.com/apple/swift-openapi-generator/issues/165

### Modifications

- Enable new rules in swift-format and address changes required

### Result

- New swift format rules will be implemented

### Test Plan

- Run the tests
