### PR TITLE
Disable "respectsExistingLineBreaks" in .swift-format for more consistent styling

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -14,7 +14,7 @@
   "lineLength" : 120,
   "maximumBlankLines" : 1,
   "prioritizeKeepingFunctionOutputTogether" : false,
-  "respectsExistingLineBreaks" : true,
+  "respectsExistingLineBreaks" : false,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,
     "AlwaysUseLowerCamelCase" : false,

--- a/Tests/OpenAPIURLSessionTests/Locking.swift
+++ b/Tests/OpenAPIURLSessionTests/Locking.swift
@@ -20,8 +20,7 @@ import Foundation
 /// performed manually using locks.
 ///
 /// Note: Use the `package` access modifier once min Swift version is increased.
-@_spi(Locking)
-public final class LockedValueBox<Value: Sendable>: @unchecked Sendable {
+@_spi(Locking) public final class LockedValueBox<Value: Sendable>: @unchecked Sendable {
     private let lock: NSLock = {
         let lock = NSLock()
         lock.name = "com.apple.swift-openapi-urlsession.lock.LockedValueBox"
@@ -31,9 +30,7 @@ public final class LockedValueBox<Value: Sendable>: @unchecked Sendable {
     /// Initializes a new `LockedValueBox` instance with the provided initial value.
     ///
     /// - Parameter value: The initial value to store in the `LockedValueBox`.
-    public init(_ value: Value) {
-        self.value = value
-    }
+    public init(_ value: Value) { self.value = value }
     /// Perform an operation on the value in a synchronized manner.
     ///
     /// - Parameter work: A closure that takes an inout reference to the wrapped value and returns a result.
@@ -42,9 +39,7 @@ public final class LockedValueBox<Value: Sendable>: @unchecked Sendable {
     /// - Returns: The result of the closure passed to `work`.
     public func withValue<R>(_ work: (inout Value) throws -> R) rethrows -> R {
         lock.lock()
-        defer {
-            lock.unlock()
-        }
+        defer { lock.unlock() }
         return try work(&value)
     }
 }

--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -37,16 +37,10 @@ class URLSessionTransportTests: XCTestCase {
             scheme: nil,
             authority: nil,
             path: "/hello%20world/Maria?greeting=Howdy",
-            headerFields: [
-                .init("x-mumble2")!: "mumble"
-            ]
+            headerFields: [.init("x-mumble2")!: "mumble"]
         )
         let body: HTTPBody = "👋"
-        let urlRequest = try await URLRequest(
-            request,
-            body: body,
-            baseURL: URL(string: "http://example.com/api")!
-        )
+        let urlRequest = try await URLRequest(request, body: body, baseURL: URL(string: "http://example.com/api")!)
         XCTAssertEqual(urlRequest.url, URL(string: "http://example.com/api/hello%20world/Maria?greeting=Howdy"))
         XCTAssertEqual(urlRequest.httpMethod, "POST")
         XCTAssertEqual(urlRequest.allHTTPHeaderFields?.count, 1)
@@ -91,9 +85,7 @@ class URLSessionTransportTests: XCTestCase {
             scheme: nil,
             authority: nil,
             path: "/hello%20world/Maria?greeting=Howdy",
-            headerFields: [
-                .init("x-mumble1")!: "mumble"
-            ]
+            headerFields: [.init("x-mumble1")!: "mumble"]
         )
         let requestBody: HTTPBody = "👋"
         let (response, maybeResponseBody) = try await transport.send(
@@ -128,18 +120,13 @@ class MockURLProtocol: URLProtocol {
     override func startLoading() {
         Self.recordedHTTPRequests.withValue { $0.append(self.request) }
         guard let url = self.request.url else { return }
-        guard let response = Self.mockHTTPResponses.withValue({ $0[url] }) else {
-            return
-        }
+        guard let response = Self.mockHTTPResponses.withValue({ $0[url] }) else { return }
         switch response {
         case .success(let mockResponse):
             client?.urlProtocol(self, didReceive: mockResponse.response, cacheStoragePolicy: .notAllowed)
-            if let data = mockResponse.body {
-                client?.urlProtocol(self, didLoad: data)
-            }
+            if let data = mockResponse.body { client?.urlProtocol(self, didLoad: data) }
             client?.urlProtocolDidFinishLoading(self)
-        case let .failure(error):
-            client?.urlProtocol(self, didFailWithError: error)
+        case let .failure(error): client?.urlProtocol(self, didFailWithError: error)
         }
     }
 


### PR DESCRIPTION
### Motivation

- Relates to [#230](https://github.com/apple/swift-openapi-generator/issues/230)

### Modifications

- Disable respectsExistingLineBreaks .swift-format rule and address changes requested

### Result

- One of the .swift-format rules will be disabled

### Test Plan

- Run Tests
