### PR TITLE
Use APIs available on older macOS in tests

### DIFF
--- a/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
@@ -60,10 +60,12 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         XCTAssertNil(inputStream.streamError)
 
         // Check the output stream closes gracefully in response to the input stream closing.
-        HTTPBodyOutputStreamBridge.streamQueue.asyncAndWait {
-            XCTAssertEqual(requestStream.outputStream.streamStatus, .closed)
-            XCTAssertNil(requestStream.outputStream.streamError)
-        }
+        HTTPBodyOutputStreamBridge.streamQueue.asyncAndWait(
+            execute: DispatchWorkItem {
+                XCTAssertEqual(requestStream.outputStream.streamStatus, .closed)
+                XCTAssertNil(requestStream.outputStream.streamError)
+            }
+        )
     }
 
     func testHTTPBodyOutputStreamBridgeBackpressure() async throws {

--- a/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift
@@ -305,7 +305,7 @@ class URLSessionBidirectionalStreamingTests: XCTestCase {
         // Just count the bytes received and verify the total matches what the server sent.
         case count
         // Add some artificial delay to simulate business logic to show how the backpressure mechanism works (or not).
-        case delay(Duration)
+        case delay(TimeAmount)
     }
 
     func testStreamingDownload(
@@ -387,7 +387,7 @@ class URLSessionBidirectionalStreamingTests: XCTestCase {
                 for try await receivedResponseChunk in responseBody! {
                     print("Client received some response body bytes (numBytes: \(receivedResponseChunk.count))")
                     print("Client doing fake work for \(delay)s")
-                    try await Task.sleep(for: delay)
+                    try await Task.sleep(nanoseconds: UInt64(delay.nanoseconds))
                 }
             }
 


### PR DESCRIPTION
### Motivation

The tests fail to compile on anything older than macOS 13, because they
use a number of APIs only available in macOS 13+:

- `Duration`
- `Task.sleep(for:)`
- `DispatchQueue.asyncAndWait` (closure variant)

### Modifications

Use the following APIs instead:

- `NIO.TimeInterval` (we have NIO dependency in tests already).
- `Task.sleep(nanoseconds:)`
- `DispatchQueue.asyncAndWait(execute:)`

### Result

Tests can be built on older platforms.