### PR TITLE
Avoid double continuation resume in URLSession delegate in corner case

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionBidirectionalStreaming/BidirectionalStreamingURLSessionDelegate.swift
+++ b/Sources/OpenAPIURLSession/URLSessionBidirectionalStreaming/BidirectionalStreamingURLSessionDelegate.swift
@@ -164,7 +164,8 @@ final class BidirectionalStreamingURLSessionDelegate: NSObject, URLSessionTaskDe
     {
         callbackLock.withLock {
             debug("Task delegate: didReceive response")
-            self.responseContinuation?.resume(returning: response)
+            responseContinuation?.resume(returning: response)
+            responseContinuation = nil
             return .allow
         }
     }
@@ -173,7 +174,10 @@ final class BidirectionalStreamingURLSessionDelegate: NSObject, URLSessionTaskDe
         callbackLock.withLock {
             debug("Task delegate: didCompleteWithError (error: \(String(describing: error)))")
             responseBodyStreamSource.finish(throwing: error)
-            if let error { responseContinuation?.resume(throwing: error) }
+            if let error {
+                responseContinuation?.resume(throwing: error)
+                responseContinuation = nil
+            }
         }
     }
 }

--- a/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/URLSessionBidirectionalStreamingTests.swift
@@ -238,6 +238,15 @@ class URLSessionBidirectionalStreamingTests: XCTestCase {
         }
     }
 
+    func testStreamingDownload_1kChunk_100Chunks_100BDownloadWatermark() async throws {
+        try await testStreamingDownload(
+            responseChunk: (1...1024).map { _ in .random(in: (.min..<(.max))) }[...],
+            numResponseChunks: 100,
+            responseStreamWatermarks: (low: 100, high: 100),
+            verification: .none
+        )
+    }
+
     func testStreamingDownload_1kChunk_10kChunks_100BDownloadWatermark() async throws {
         try await testStreamingDownload(
             responseChunk: (1...1024).map { _ in .random(in: (.min..<(.max))) }[...],
@@ -306,6 +315,8 @@ class URLSessionBidirectionalStreamingTests: XCTestCase {
         case count
         // Add some artificial delay to simulate business logic to show how the backpressure mechanism works (or not).
         case delay(TimeAmount)
+        // Do no verification: useful for just pulling as fast as possible for testing for races.
+        case none
     }
 
     func testStreamingDownload(
@@ -389,6 +400,7 @@ class URLSessionBidirectionalStreamingTests: XCTestCase {
                     print("Client doing fake work for \(delay)s")
                     try await Task.sleep(nanoseconds: UInt64(delay.nanoseconds))
                 }
+            case .none: break
             }
 
             group.cancelAll()


### PR DESCRIPTION
### Motivation

If the request completes with error after the response has already been received we can potentially resume a continuation twice. This was shown by running some of the tests in long loop.

### Modifications

- Add a shorter test that more reliably reproduced the issue. 
- Add the fix: to set the continuation to `nil` after resuming it, while still holding the lock.

### Result

- Removed a source of a potential runtime crash.

### Test Plan

- The newly added test, which reliably failed, now reliably passes.