### PR TITLE
Prep for 1.0 alpha, adapted to runtime changes in main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", branch: "main"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     ],

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -142,8 +142,7 @@ extension HTTPBody.Length {
         if urlResponse.expectedContentLength == -1 {
             self = .unknown
         } else {
-            // TODO: Content-Length will change to Int64: https://github.com/apple/swift-openapi-generator/issues/354
-            self = .known(Int(urlResponse.expectedContentLength))
+            self = .known(urlResponse.expectedContentLength)
         }
     }
 }

--- a/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
@@ -30,7 +30,7 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: false)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(requestBytes.count), iterationBehavior: .single)
+        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -77,7 +77,7 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(requestBytes.count), iterationBehavior: .single)
+        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -129,7 +129,7 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(requestBytes.count), iterationBehavior: .single)
+        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -183,7 +183,7 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(requestBytes.count), iterationBehavior: .single)
+        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -240,7 +240,7 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(requestBytes.count), iterationBehavior: .single)
+        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?

--- a/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionBidirectionalStreamingTests/HTTPBodyOutputStreamTests.swift
@@ -30,7 +30,11 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: false)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
+        let requestBody = HTTPBody(
+            requestByteSequence,
+            length: .known(Int64(requestBytes.count)),
+            iterationBehavior: .single
+        )
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -77,7 +81,11 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
+        let requestBody = HTTPBody(
+            requestByteSequence,
+            length: .known(Int64(requestBytes.count)),
+            iterationBehavior: .single
+        )
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -129,7 +137,11 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
+        let requestBody = HTTPBody(
+            requestByteSequence,
+            length: .known(Int64(requestBytes.count)),
+            iterationBehavior: .single
+        )
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -183,7 +195,11 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
+        let requestBody = HTTPBody(
+            requestByteSequence,
+            length: .known(Int64(requestBytes.count)),
+            iterationBehavior: .single
+        )
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?
@@ -240,7 +256,11 @@ class HTTPBodyOutputStreamBridgeTests: XCTestCase {
         let requestBytes = (0...numBytes).map { UInt8($0) }
         let requestChunks = requestBytes.chunks(of: chunkSize)
         let requestByteSequence = MockAsyncSequence(elementsToVend: requestChunks, gatingProduction: true)
-        let requestBody = HTTPBody(requestByteSequence, length: .known(Int64(requestBytes.count)), iterationBehavior: .single)
+        let requestBody = HTTPBody(
+            requestByteSequence,
+            length: .known(Int64(requestBytes.count)),
+            iterationBehavior: .single
+        )
 
         // Create a pair of bound streams with a tiny buffer to be the bottleneck for backpressure.
         var inputStream: InputStream?

--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -146,13 +146,13 @@ class URLSessionTransportPlatformSupportTests: XCTestCase {
 
 func testHTTPRedirect(
     transport: any ClientTransport,
-    requestBodyIterationBehavior: HTTPBody.IterationBehavior,
+    requestBodyIterationBehavior: IterationBehavior,
     expectFailureDueToIterationBehavior: Bool
 ) async throws {
     let requestBodyChunks = ["✊", "✊", " ", "knock", " ", "knock!"]
     let requestBody = HTTPBody(
         requestBodyChunks.async,
-        length: .known(requestBodyChunks.joined().lengthOfBytes(using: .utf8)),
+        length: .known(Int64(requestBodyChunks.joined().lengthOfBytes(using: .utf8))),
         iterationBehavior: requestBodyIterationBehavior
     )
 


### PR DESCRIPTION
### Motivation

On main, the HTTPBody length type changed from Int to Int64.

### Modifications

Adapted the transport with this change.

### Result

Repo builds again when using the latest runtime.

### Test Plan

Adapted tests.
