### PR TITLE
Remove AsyncStream.makeStream backports now we support only Swift 5.9+

### DIFF
--- a/Tests/OpenAPIURLSessionTests/TestUtils.swift
+++ b/Tests/OpenAPIURLSessionTests/TestUtils.swift
@@ -153,31 +153,6 @@ final class LockedValueBox<Value>: @unchecked Sendable where Value: Sendable {
     }
 }
 
-#if swift(<5.9)
-extension AsyncStream {
-    static func makeStream(
-        of elementType: Element.Type = Element.self,
-        bufferingPolicy limit: Self.Continuation.BufferingPolicy = .unbounded
-    ) -> (stream: Self, continuation: Self.Continuation) {
-        var continuation: Self.Continuation!
-        let stream = Self(bufferingPolicy: limit) { continuation = $0 }
-        return (stream, continuation)
-    }
-}
-
-extension AsyncThrowingStream {
-    static func makeStream(
-        of elementType: Element.Type = Element.self,
-        throwing failureType: Failure.Type = Failure.self,
-        bufferingPolicy limit: Self.Continuation.BufferingPolicy = .unbounded
-    ) -> (stream: Self, continuation: Self.Continuation) where Failure == Error {
-        var continuation: Self.Continuation!
-        let stream = Self(bufferingPolicy: limit) { continuation = $0 }
-        return (stream, continuation!)
-    }
-}
-#endif  // #if swift(<5.9)
-
 extension AsyncSequence {
     /// Collect all elements in the sequence into an array.
     func collect() async throws -> [Element] {


### PR DESCRIPTION
### Motivation

We had some code in an `#if swift(<5.9)` block, which can now be removed because we only support Swift 5.9 and newer.

### Modifications

Remove code required to support Swift 5.8.

### Result

Removed dead code.

### Test Plan

Tests pass.