### PR TITLE
Use 5.9.0 explicitly to avoid getting 5.9.1

### DIFF
--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -6,7 +6,7 @@ services:
     build:
       args:
         ubuntu_version: "jammy"
-        swift_version: "5.9"
+        swift_version: "5.9.0"
 
   test:
     image: *image


### PR DESCRIPTION
### Motivation

In Swift 5.9.1, there were some improvements to corelibs-foundation around Sendability, however we need to keep supporting 5.9.0 toolchains.

One thing I learned today is that if you specify "5.9" from the docker registry, you might get "5.9.1", which we explicitly _don't_ want, as we could miss issues that only show up on "5.9.0".

One option would be to have two pipelines, one for 5.9.0 and 5.9.1, however I don't think it's necessary, as we already have a 5.10 pipeline, verifying that newer toolchains work.

This PR bumps _down_ the 5.9 pipeline explicitly to use 5.9.0.

### Modifications

Explicitly require 5.9.0, instead of using the latest 5.9 toolchain.

### Result

More issues are caught in CI instead of only hitting users who use 5.9.0 later.

### Test Plan

Ran locally, still passes.
