### PR TITLE
Explicit dependency on HTTPTypes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     ],
@@ -51,6 +52,7 @@ let package = Package(
             dependencies: [
                 .product(name: "DequeModule", package: "swift-collections"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "HTTPTypes", package: "swift-http-types")
             ],
             swiftSettings: swiftSettings
         ),


### PR DESCRIPTION
### Motivation

Recent SwiftPM versions seem to be a bit stricter about using (i.e., `import ...`) transitive dependencies without explicitly declaring them as direct dependencies.

### Modifications

Explicitly depend on the HTTPTypes module from swift-http-types.

### Result

More explicitly declare the dependency graph.

### Test Plan

All tests pass.

