### PR TITLE
Add Docker Compose file for Swift 5.9.0

### DIFF
--- a/docker/docker-compose.2204.590.yaml
+++ b/docker/docker-compose.2204.590.yaml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  runtime-setup:
+    image: &image swift-openapi-urlsession:22.04-5.9.0
+    build:
+      args:
+        ubuntu_version: "jammy"
+        swift_version: "5.9.0"
+
+  test:
+    image: *image
+    environment:
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
+
+  shell:
+    image: *image


### PR DESCRIPTION
### Motivation

As we approach 1.0 we want to make sure that we compile without warnings (or remarks) on all the Swift versions we claim to support. As discussed in https://github.com/apple/swift-openapi-urlsession/pull/35, this turns out to be subtly different between 5.9.0 and 5.9.1. We cannot drop support for 5.9.0 because the latest released (non-seed) Xcode still uses 5.9.0. However 5.9.1 is the latest release for Linux.

While we don't expect to do this for all patch versions of Swift, in this instance we'd like to add a pipeline for Swift 5.9.0 until such a time that we can expect everyone to be using 5.9.1, which will be some time after an Xcode release with this version.

This will allow us to progress squashing the remarks on 5.9.1 with confidence that we aren't introducing warnings on 5.9.0, which could result in an error for adopters if they compile our generated code with warnings-as-errors.

### Modifications

This PR adds a new Docker Compose file to explicitly use `5.9.0`.

It leaves the existing `5.9` pipeline to pull `5.9-jammy` which resolves to `5.9.1`, and will continue to resolve to the latest 5.9.x version.

### Result

We can now stand up a new CI pipeline for Swift 5.9.0 explicitly, which we can use this PR to validate.