### PR TITLE
Tolerate both CancellationError and URLError in CancellationTests

### DIFF
--- a/Tests/OpenAPIURLSessionTests/NIOAsyncHTTP1TestServer.swift
+++ b/Tests/OpenAPIURLSessionTests/NIOAsyncHTTP1TestServer.swift
@@ -59,7 +59,7 @@ final class AsyncTestHTTP1Server {
                     for try await connectionChannel in inbound {
                         group.addTask {
                             do {
-                                debug("Sevrer handling new connection")
+                                debug("Server handling new connection")
                                 try await connectionHandler(connectionChannel)
                                 debug("Server done handling connection")
                             } catch { debug("Server error handling connection: \(error)") }

--- a/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
+++ b/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
@@ -150,11 +150,11 @@ func testTaskCancelled(_ cancellationPoint: CancellationPoint, transport: URLSes
                 await XCTAssertThrowsError(try await task.value) { error in XCTAssertTrue(error is CancellationError) }
             case .beforeSendingRequestBody, .partwayThroughSendingRequestBody:
                 await XCTAssertThrowsError(try await task.value) { error in
-                    guard let urlError = error as? URLError else {
-                        XCTFail()
-                        return
+                    switch error {
+                    case is CancellationError: break
+                    case is URLError: XCTAssertEqual((error as! URLError).code, .cancelled)
+                    default: XCTFail("Unexpected error: \(error)")
                     }
-                    XCTAssertEqual(urlError.code, .cancelled)
                 }
             case .beforeConsumingResponseBody, .partwayThroughConsumingResponseBody, .afterConsumingResponseBody:
                 try await task.value


### PR DESCRIPTION
### Motivation

When cancelling a Swift concurrency task during a streaming request then the error returned might be `URLError` with `.cancelled` code or `CancellationError`. The tests tried to be smart and expect just one of these depending on which stage of the request we were at, but there are still some races, and this test fails very rarely because a `CancellationError` was thrown instead of a `URLError`.

### Modifications

This patch updates the test to tolerate both kinds of error at this stage of the request.

### Result

The test will pass if the error is either `URLError` with `.cancelled` or `CancellationError`, and continue to fail if there is any other kind of error or no error.

### Test Plan

Existing tests, which failed when run repeatedly for 1k runs, now pass when run for 10k runs.