### PR TITLE
[BUG] Fix: resolve issue with HTTP headers may lost some cookies

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -193,7 +193,18 @@ extension URLRequest {
         }
         self.init(url: url)
         self.httpMethod = request.method.rawValue
-        for header in request.headerFields { setValue(header.value, forHTTPHeaderField: header.name.canonicalName) }
+        var cookies = [String]()
+        for header in request.headerFields {
+            if header.name == .cookie {
+                cookies.append(header.value)
+            } else {
+                setValue(header.value, forHTTPHeaderField: header.name.canonicalName)
+            }
+        }
+        if !cookies.isEmpty {
+            let cookie = cookies.joined(separator: "; ")
+            setValue(cookie, forHTTPHeaderField: HTTPField.Name.cookie.canonicalName)
+        }
     }
 }
 

--- a/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
+++ b/Tests/OpenAPIURLSessionTests/URLSessionTransportTests.swift
@@ -27,18 +27,21 @@ class URLSessionTransportConverterTests: XCTestCase {
     static override func setUp() { OpenAPIURLSession.debugLoggingEnabled = false }
 
     func testRequestConversion() async throws {
-        let request = HTTPRequest(
+        var request = HTTPRequest(
             method: .post,
             scheme: nil,
             authority: nil,
             path: "/hello%20world/Maria?greeting=Howdy",
             headerFields: [.init("x-mumble2")!: "mumble"]
         )
+        let cookie = "uid=urlsession; sid=0123456789-9876543210"
+        request.headerFields[.cookie] = cookie
         let urlRequest = try URLRequest(request, baseURL: URL(string: "http://example.com/api")!)
         XCTAssertEqual(urlRequest.url, URL(string: "http://example.com/api/hello%20world/Maria?greeting=Howdy"))
         XCTAssertEqual(urlRequest.httpMethod, "POST")
-        XCTAssertEqual(urlRequest.allHTTPHeaderFields?.count, 1)
+        XCTAssertEqual(urlRequest.allHTTPHeaderFields?.count, 2)
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "x-mumble2"), "mumble")
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: HTTPField.Name.cookie.rawName), cookie)
     }
 
     func testResponseConversion() async throws {


### PR DESCRIPTION
### Motivation

I use a custom `ClientMiddleware` to inject cookie for some APIs, but I found the final Request always lost some cookies.

https://github.com/apple/swift-http-types/blob/e6359663d11a5c7d2340ac81f2e025d5c5fb0e14/Sources/HTTPTypes/HTTPFields.swift#L190

The reason is that there may be more than one cookie in the `HTTPRequest`'s `headerFields`. Before setting them to the `URLRequest`, you must join them together. Otherwise, only the last cookie will be effective due to simple overwriting.

### Modifications

Check `header.name` before setting it to the `URLRequest `

### Result

All cookies now work well.

### Test Plan

Not yet.
