### PR TITLE
Add Mac Catalyst support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ if ProcessInfo.processInfo.environment["SWIFT_OPENAPI_STRICT_CONCURRENCY"].flatM
 let package = Package(
     name: "swift-openapi-urlsession",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
+        .macOS(.v10_15), .macCatalyst(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .visionOS(.v1)
     ],
     products: [
         .library(


### PR DESCRIPTION
### Motivation

Support the transport in Mac Catalyst apps.

### Modifications

Add the platform requirement to Package.swift.

### Result

Builds correctly for Mac Catalyst now.

### Test Plan

Unit tests passed.
