### PR TITLE
Remove public modifiers from an internal extension

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -249,12 +249,12 @@ extension HTTPField {
 
 extension URLSessionTransportError: LocalizedError {
     /// A localized message describing what error occurred.
-    public var errorDescription: String? { description }
+    var errorDescription: String? { description }
 }
 
 extension URLSessionTransportError: CustomStringConvertible {
     /// A textual representation of this instance.
-    public var description: String {
+    var description: String {
         switch self {
         case let .invalidRequestURL(path: path, method: method, baseURL: baseURL):
             return


### PR DESCRIPTION
### Motivation

The `public` modifier of members in an extension of an internal type doesn't actually make them public, and can be confusing when reading the code.

### Modifications

Remove the public modifiers.

### Result

Less confusing code.

### Test Plan

Tests still pass.
