### PR TITLE
CI use 6.1 nightlies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,5 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
 
   cxx-interop:


### PR DESCRIPTION
CI use 6.1 nightlies now that Swift development is happening in the 6.1 branch