### PR TITLE
Add support for opting out of streaming HTTP bodies

### DIFF
--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -97,7 +97,7 @@ public struct URLSessionTransport: ClientTransport {
             }
         }
 
-        enum Implementation: Sendable {
+        enum Implementation {
             case buffering
             case streaming(requestBodyStreamBufferSize: Int, responseBodyStreamWatermarks: (low: Int, high: Int))
         }

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -71,14 +71,14 @@ public struct URLSessionTransport: ClientTransport {
         ///   If none is provided, the system uses the shared URLSession.
         public init(session: URLSession = .shared) { self.init(session: session, implementation: .platformDefault) }
 
-        enum Implementation {
+        public enum Implementation: Sendable {
             case buffering
             case streaming(requestBodyStreamBufferSize: Int, responseBodyStreamWatermarks: (low: Int, high: Int))
         }
 
-        var implementation: Implementation
+        public var implementation: Implementation
 
-        init(session: URLSession = .shared, implementation: Implementation = .platformDefault) {
+        public init(session: URLSession = .shared, implementation: Implementation = .platformDefault) {
             self.session = session
             if case .streaming = implementation {
                 precondition(Implementation.platformSupportsStreaming, "Streaming not supported on platform")
@@ -352,7 +352,7 @@ extension URLSessionTransport.Configuration.Implementation {
         #endif
     }
 
-    static var platformDefault: Self {
+    public static var platformDefault: Self {
         guard platformSupportsStreaming else { return .buffering }
         return .streaming(
             requestBodyStreamBufferSize: 16 * 1024,

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -78,7 +78,7 @@ public struct URLSessionTransport: ClientTransport {
         /// Creates a new configuration with the provided session.
         /// - Parameter session: The URLSession used for performing HTTP operations.
         ///   If none is provided, the system uses the shared URLSession.
-        public init(session: URLSession) { self.init(session: session, implementation: .platformDefault) }
+        public init(session: URLSession = .shared) { self.init(session: session, implementation: .platformDefault) }
         /// Specifies the mode in which HTTP request and response bodies are processed.
         public struct HTTPBodyProcessingMode: Sendable {
             /// Exposing the internal implementation directly.

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -74,8 +74,10 @@ public struct URLSessionTransport: ClientTransport {
             let implementation = httpBodyProcessingMode.implementation
             self.init(session: session, implementation: implementation)
         }
+        /// Creates a new configuration with the provided session.
+        /// - Parameter session: The URLSession used for performing HTTP operations.
+        public init(session: URLSession) { self.init(session: session, implementation: .platformDefault) }
         /// Specifies the mode in which HTTP request and response bodies are processed.
-
         public struct HTTPBodyProcessingMode: Sendable {
             /// Exposing the internal implementation directly.
             fileprivate let implementation: Configuration.Implementation

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -75,7 +75,7 @@ public struct URLSessionTransport: ClientTransport {
             self.init(session: session, implementation: implementation)
         }
         /// Specifies the mode in which HTTP request and response bodies are processed.
-       
+
         public struct HTTPBodyProcessingMode: Sendable {
             /// Exposing the internal implementation directly.
             fileprivate let implementation: Configuration.Implementation
@@ -95,7 +95,6 @@ public struct URLSessionTransport: ClientTransport {
         }
 
         var implementation: Implementation
-        
         init(session: URLSession = .shared, implementation: Implementation = .platformDefault) {
             self.session = session
             if case .streaming = implementation {
@@ -111,7 +110,9 @@ public struct URLSessionTransport: ClientTransport {
 
     /// Creates a new URLSession-based transport.
     /// - Parameter configuration: A set of configuration values used by the transport.
-    public init(configuration: Configuration = .init(httpBodyProcessingMode: .platformDefault)) { self.configuration = configuration }
+    public init(configuration: Configuration = .init(httpBodyProcessingMode: .platformDefault)) {
+        self.configuration = configuration
+    }
 
     /// Sends the underlying HTTP request and returns the received HTTP response.
     /// - Parameters:

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -70,7 +70,6 @@ public struct URLSessionTransport: ClientTransport {
         /// - Parameter session: The URLSession used for performing HTTP operations.
         ///   If none is provided, the system uses the shared URLSession.
         public init(session: URLSession = .shared) { self.init(session: session, implementation: .platformDefault) }
-        
         /// Specifies the mode in which HTTP request and response bodies are processed.
         public enum HTTPBodyProcessingMode {
             /// Processes the HTTP body incrementally as bytes become available.
@@ -85,15 +84,15 @@ public struct URLSessionTransport: ClientTransport {
             /// Use this mode when it's necessary or simpler to handle complete data payloads at once.
             case buffered
         }
-        
+        /// Creates a new configuration with the provided session.
+        /// - Parameters:
+        ///   - session: The URLSession used for performing HTTP operations.
+        ///   - httpBodyProcessingMode: The mode used to process HTTP request and response bodies.
         public init(session: URLSession = .shared, httpBodyProcessingMode: HTTPBodyProcessingMode) {
             self.session = session
             switch httpBodyProcessingMode {
-                
-            case .streamed:
-                self.implementation = .defaultStreaming
-            case .buffered:
-                self.implementation = .buffering
+            case .streamed: self.implementation = .defaultStreaming
+            case .buffered: self.implementation = .buffering
             }
         }
 
@@ -382,7 +381,6 @@ extension URLSessionTransport.Configuration.Implementation {
         guard platformSupportsStreaming else { return .buffering }
         return .defaultStreaming
     }
-    
     static var defaultStreaming: Self {
         .streaming(
             requestBodyStreamBufferSize: 16 * 1024,

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -378,7 +378,7 @@ extension URLSessionTransport.Configuration.Implementation {
         #endif
     }
 
-    public static var platformDefault: Self {
+    static var platformDefault: Self {
         guard platformSupportsStreaming else { return .buffering }
         return .defaultStreaming
     }

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -114,9 +114,7 @@ public struct URLSessionTransport: ClientTransport {
 
     /// Creates a new URLSession-based transport.
     /// - Parameter configuration: A set of configuration values used by the transport.
-    public init(configuration: Configuration = .init(httpBodyProcessingMode: .platformDefault)) {
-        self.configuration = configuration
-    }
+    public init(configuration: Configuration = .init()) { self.configuration = configuration }
 
     /// Sends the underlying HTTP request and returns the received HTTP response.
     /// - Parameters:

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -69,7 +69,7 @@ public struct URLSessionTransport: ClientTransport {
         /// Creates a new configuration with the provided session.
         /// - Parameters:
         ///   - session: The URLSession used for performing HTTP operations.
-        /// If none is provided, the system uses the shared URLSession.
+        ///     If none is provided, the system uses the shared URLSession.
         ///   - httpBodyProcessingMode: The mode used to process HTTP request and response bodies.
         public init(session: URLSession = .shared, httpBodyProcessingMode: HTTPBodyProcessingMode = .platformDefault) {
             let implementation = httpBodyProcessingMode.implementation
@@ -77,7 +77,7 @@ public struct URLSessionTransport: ClientTransport {
         }
         /// Creates a new configuration with the provided session.
         /// - Parameter session: The URLSession used for performing HTTP operations.
-        /// If none is provided, the system uses the shared URLSession.
+        ///   If none is provided, the system uses the shared URLSession.
         public init(session: URLSession) { self.init(session: session, implementation: .platformDefault) }
         /// Specifies the mode in which HTTP request and response bodies are processed.
         public struct HTTPBodyProcessingMode: Sendable {

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -71,15 +71,12 @@ public struct URLSessionTransport: ClientTransport {
         ///   - session: The URLSession used for performing HTTP operations.
         ///   - httpBodyProcessingMode: The mode used to process HTTP request and response bodies.
         public init(session: URLSession = .shared, httpBodyProcessingMode: HTTPBodyProcessingMode = .platformDefault) {
-            self.session = session
             let implementation = httpBodyProcessingMode.implementation
-            if case .streaming = implementation {
-                precondition(Implementation.platformSupportsStreaming, "Streaming not supported on platform")
-            }
-            self.implementation = implementation
+            self.init(session: session, implementation: implementation)
         }
         /// Specifies the mode in which HTTP request and response bodies are processed.
-        public struct HTTPBodyProcessingMode {
+       
+        public struct HTTPBodyProcessingMode: Sendable {
             /// Exposing the internal implementation directly.
             fileprivate let implementation: Configuration.Implementation
 
@@ -98,6 +95,14 @@ public struct URLSessionTransport: ClientTransport {
         }
 
         var implementation: Implementation
+        
+        init(session: URLSession = .shared, implementation: Implementation = .platformDefault) {
+            self.session = session
+            if case .streaming = implementation {
+                precondition(Implementation.platformSupportsStreaming, "Streaming not supported on platform")
+            }
+            self.implementation = implementation
+        }
 
     }
 
@@ -106,7 +111,7 @@ public struct URLSessionTransport: ClientTransport {
 
     /// Creates a new URLSession-based transport.
     /// - Parameter configuration: A set of configuration values used by the transport.
-    public init(configuration: Configuration = .init()) { self.configuration = configuration }
+    public init(configuration: Configuration = .init(httpBodyProcessingMode: .platformDefault)) { self.configuration = configuration }
 
     /// Sends the underlying HTTP request and returns the received HTTP response.
     /// - Parameters:

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -99,6 +99,7 @@ public struct URLSessionTransport: ClientTransport {
         }
 
         var implementation: Implementation
+
         init(session: URLSession = .shared, implementation: Implementation = .platformDefault) {
             self.session = session
             if case .streaming = implementation {
@@ -106,7 +107,6 @@ public struct URLSessionTransport: ClientTransport {
             }
             self.implementation = implementation
         }
-
     }
 
     /// A set of configuration values used by the transport.

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -69,6 +69,7 @@ public struct URLSessionTransport: ClientTransport {
         /// Creates a new configuration with the provided session.
         /// - Parameters:
         ///   - session: The URLSession used for performing HTTP operations.
+        /// If none is provided, the system uses the shared URLSession.
         ///   - httpBodyProcessingMode: The mode used to process HTTP request and response bodies.
         public init(session: URLSession = .shared, httpBodyProcessingMode: HTTPBodyProcessingMode = .platformDefault) {
             let implementation = httpBodyProcessingMode.implementation
@@ -76,6 +77,7 @@ public struct URLSessionTransport: ClientTransport {
         }
         /// Creates a new configuration with the provided session.
         /// - Parameter session: The URLSession used for performing HTTP operations.
+        /// If none is provided, the system uses the shared URLSession.
         public init(session: URLSession) { self.init(session: session, implementation: .platformDefault) }
         /// Specifies the mode in which HTTP request and response bodies are processed.
         public struct HTTPBodyProcessingMode: Sendable {

--- a/Sources/OpenAPIURLSession/URLSessionTransport.swift
+++ b/Sources/OpenAPIURLSession/URLSessionTransport.swift
@@ -85,17 +85,10 @@ public struct URLSessionTransport: ClientTransport {
 
             private init(_ implementation: Configuration.Implementation) { self.implementation = implementation }
 
-            /// Processes the HTTP body incrementally as bytes become available.
-            ///
-            /// Use this mode to handle large payloads efficiently or to begin processing
-            /// before the entire body has been received. Will throw a `URLSessionTransportError.streamingNotSupported`
-            /// error if not available on the platform.
-            public static let streamed = HTTPBodyProcessingMode(.defaultStreaming)
-            /// Waits until the entire HTTP body has been received before processing begins.
-            ///
-            /// Use this mode when it's necessary or simpler to handle complete data payloads at once.
+            /// Use this mode to force URLSessionTransport to transfer data in a buffered mode, even if
+            /// streaming would be available on the platform.
             public static let buffered = HTTPBodyProcessingMode(.buffering)
-            /// Automatically chooses the optimal transport mode, based on the platform being used.
+            /// Data is transfered via streaming if available on the platform, else it falls back to buffering.
             public static let platformDefault = HTTPBodyProcessingMode(.platformDefault)
         }
 
@@ -375,10 +368,7 @@ extension URLSessionTransport.Configuration.Implementation {
 
     static var platformDefault: Self {
         guard platformSupportsStreaming else { return .buffering }
-        return .defaultStreaming
-    }
-    static var defaultStreaming: Self {
-        .streaming(
+        return .streaming(
             requestBodyStreamBufferSize: 16 * 1024,
             responseBodyStreamWatermarks: (low: 16 * 1024, high: 32 * 1024)
         )

--- a/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
+++ b/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
@@ -18,6 +18,7 @@ import HTTPTypes
 import NIO
 import OpenAPIRuntime
 import XCTest
+import NIOHTTP1
 @testable import OpenAPIURLSession
 
 enum CancellationPoint: CaseIterable {

--- a/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
+++ b/Tests/OpenAPIURLSessionTests/TaskCancellationTests.swift
@@ -18,7 +18,6 @@ import HTTPTypes
 import NIO
 import OpenAPIRuntime
 import XCTest
-import NIOHTTP1
 @testable import OpenAPIURLSession
 
 enum CancellationPoint: CaseIterable {


### PR DESCRIPTION
### Motivation

swift-openapi-urlsession offers both a streaming and buffering implementation for sending/receiving data. Which implementation is used is currently based on the platform its running on, mainly because "streaming" is not supported on all platforms. It is currently not possible to "force" buffering, even if one wants/needs it.

While adding https://github.com/kean/Pulse to my app, a tool for debugging network requests, I noticed that Pulse was not showing request bodies (https://github.com/apple/swift-openapi-generator/issues/749) - because Pulse appears not do work with the streamed data mode. Neither does https://github.com/pmusolino/Wormholy.

I have now made switching .buffered mode public, allowing developers to choose which mode they want to work with. This fixes the issue I have with Pulse - which previously was not showing any request body.

<img src="https://github.com/user-attachments/assets/ef6be019-d8a1-4f82-b411-8ffac5e3012f" alt="RocketSim_Screenshot_iPhone_16_Pro_6 3_2025-03-25_14 51 41" width="50%">


### Modifications

I made Implementation, platformDefault and an already existing init public. I had to make the Implementation enum Sendable, else Xcode produced a warning.

### Result

There are no functional changes, other than making previously private functionality public. Technically someone could now manually try to set "streaming" mode on a platform that doesn't support it, but then an error is thrown correctly.

### Test Plan

Tested the change in my own app: switching to buffered mode was now possible, and now tools like Pulse work correctly.
