### PR TITLE
Enable macOS CI on merge to main and daily timer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,3 +20,9 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      build_scheme: swift-openapi-urlsession


### PR DESCRIPTION
Enable macOS CI on merge to main and daily timer

### Motivation:

* Improve test coverage
* Check test pass/fail status
* Monitor CI throughput

### Modifications:

Enable macOS CI to be run on all merges to main and on a daily timer.

### Result:

Improved test coverage run out-of-band at the moment so we can get a feeling for if any changes need to be made in the repo or in the CI pipelines to ensure timely and stable checks.