### PR TITLE
Enable Swift 6.1 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,15 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
+      linux_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
+      windows_6_1_enabled: true
       windows_nightly_6_1_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,12 +22,15 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
+      linux_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
+      windows_6_1_enabled: true
       windows_nightly_6_1_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 


### PR DESCRIPTION
Motivation:

Swift 6.1 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.1 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
