### PR TITLE
Add support for Android

### DIFF
--- a/Sources/OpenAPIURLSession/BufferedStream/Lock.swift
+++ b/Sources/OpenAPIURLSession/BufferedStream/Lock.swift
@@ -30,6 +30,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Bionic)
+import Bionic
 #elseif os(Windows)
 import WinSDK
 #endif


### PR DESCRIPTION
### Motivation

The current codebase is not buildable on Android since Bionic is not imported to provide the `pthread` APIs.

### Modifications

- Lock.swift: `import Bionic`

### Result

Successfully compiles for Android. 

Tested with [Skip Tools](https://skip.tools/docs/gettingstarted/#installation): `skip android build`

### Test Plan

Compile for Android with the toolchain of your choosing.
