### PR TITLE
Drop Swift 5.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
       # Disable strict concurrency checking as it intersects badly with
       # warnings-as-errors on 5.10 and later as SwiftPMs generated test manifest
       # has a non-sendable global property.
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,6 @@ jobs:
       # Disable strict concurrency checking as it intersects badly with
       # warnings-as-errors on 5.10 and later as SwiftPMs generated test manifest
       # has a non-sendable global property.
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       # TODO: Enable warnings-as-errors on 6.0.
       linux_6_0_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -strict-concurrency=complete --explicit-target-dependency-import-check error"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftOpenAPIGenerator open source project


### PR DESCRIPTION
Motivation:

Swift 5.10 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.0
* Remove Swift 5.10 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
